### PR TITLE
[WIP] Virtualbox support

### DIFF
--- a/vagrant-k8s-manual/00-ubuntu.sh
+++ b/vagrant-k8s-manual/00-ubuntu.sh
@@ -12,7 +12,7 @@ do
 done
 
 sudo apt-get update
-sudo apt-get install -y git conntrack curl 
+sudo apt-get install -y git conntrack curl python
 
 #####################################################################################
 # Make directories

--- a/vagrant-k8s-manual/01-kubernetes.sh
+++ b/vagrant-k8s-manual/01-kubernetes.sh
@@ -36,7 +36,7 @@ PATH="/vagrant/kube/bin/:$PATH"
 # Changed from $HOME to /vagrant
 DOWNLOAD_DIR="/vagrant/kube/cni-plugins"
 CNI_BIN="/opt/cni/bin/"
-mkdir ${DOWNLOAD_DIR}
+mkdir -p ${DOWNLOAD_DIR}
 cd $DOWNLOAD_DIR
 curl --silent -L $(curl -s https://api.github.com/repos/containernetworking/plugins/releases/latest | grep browser_download_url | grep 'amd64.*tgz' | head -n 1 | cut -d '"' -f 4) -o cni-plugins-amd64.tgz
 tar -xzf cni-plugins-amd64.tgz #removed -v for verbose

--- a/vagrant-k8s-manual/02-master.sh
+++ b/vagrant-k8s-manual/02-master.sh
@@ -3,13 +3,20 @@ FULL_CLUSTER=$1
 CLUSTER=$2
 
 cd /vagrant/kube
+MASTER_IP=
 MASTER_IP=$(ifconfig eth0 | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')
+if [ -z "$MASTER_IP" ]; then
+    MASTER_IP=$(ifconfig enp0s8 | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')
+fi
+echo "Using $MASTER_IP as the IP address for the Kubernetes master"
 echo $MASTER_IP | tee /vagrant/kube/masterip /vagrant/kube-win/masterip
 
 cd /vagrant/kube/certs
+chmod +x generate-certs.sh
 ./generate-certs.sh $MASTER_IP
 
 cd /vagrant/kube/manifest
+chmod +x generate.py
 ./generate.py $MASTER_IP --cluster-cidr $FULL_CLUSTER
 rm ./generate.py
 

--- a/vagrant-k8s-manual/Vagrantfile
+++ b/vagrant-k8s-manual/Vagrantfile
@@ -1,62 +1,92 @@
 $VirtualSwitchName = "External"
 
-LINUX_IMAGE = "generic/ubuntu1604"
+$LinuxImage = "ubuntu/xenial64"
 
-IMAGE = "WindowsServer1709Docker"
+$WindowsImage = "WindowsServer1709Docker"
+$SyncedFolderType = "smb"
+
 ClusterCIDR = "10.4.0.0/16"
 ClusterCIDRShort = "10.4"
 
 Vagrant.configure("2") do |config|
+
+    config.vm.provider "virtualbox" do |v|
+        $WindowsImage = "StefanScherer/windows_2016_docker"
+        $SyncedFolderType = "virtualbox"
+    end
+
     config.vm.define "k-builder", autostart: false do |subconfig|
-        subconfig.vm.box = LINUX_IMAGE
+        subconfig.vm.box = $LinuxImage
         subconfig.vm.hostname = "k-builder"
-        subconfig.vm.network :public_network, bridge: $VirtualSwitchName
-        subconfig.vm.synced_folder "../vagrant-synced/", "/vagrant", type: "smb"
+        subconfig.vm.synced_folder "../vagrant-synced/", "/vagrant", type: $SyncedFolderType
         subconfig.vm.provision "shell", path: "00-ubuntu.sh"
         subconfig.vm.provision "shell", path: "01-builder.sh"
+
         subconfig.vm.provider "hyperv" do |h|
+            subconfig.vm.network :public_network, bridge: $VirtualSwitchName
             h.enable_virtualization_extensions = true
             h.differencing_disk = true
             h.cpus = 4
             h.memory = 1024
             h.maxmemory = 4096
             h.vmname = "k-builder"
-        end   
+        end
+        subconfig.vm.provider "virtualbox" do |v|
+            subconfig.vm.network :private_network, type: "dhcp"
+            v.linked_clone = true
+            v.memory = 1024
+            v.cpus = 2
+            v.name = "k-builder"
+        end
     end    
     config.vm.define "k-m1" do |subconfig|
-        subconfig.vm.box = LINUX_IMAGE
+        subconfig.vm.box = $LinuxImage
+        subconfig.vm.synced_folder "../vagrant-synced/", "/vagrant", type: $SyncedFolderType
         subconfig.vm.hostname = "k-m1"
-        subconfig.vm.network :public_network, bridge: $VirtualSwitchName
-        subconfig.vm.synced_folder "../vagrant-synced/", "/vagrant", type: "smb"
         subconfig.vm.provision "shell", path: "00-ubuntu.sh"
         subconfig.vm.provision "shell", path: "01-kubernetes.sh"
         subconfig.vm.provision "shell", path: "02-master.sh", :args => [ClusterCIDR, ClusterCIDRShort]
         subconfig.vm.provider "hyperv" do |h|
+            subconfig.vm.network :public_network, bridge: $VirtualSwitchName
             h.enable_virtualization_extensions = true
             h.differencing_disk = true
             h.cpus = 4
             h.memory = 5000
             h.maxmemory = 5000
             h.vmname = "k-m1"
-        end   
+        end
+        subconfig.vm.provider "virtualbox" do |v|
+            subconfig.vm.network :private_network, type: "dhcp"
+            v.linked_clone = true
+            v.memory = 1024
+            v.cpus = 2
+            v.name = "k-m1"
+        end
     end
     # Not currently using Linux worker, and untested
     config.vm.define "k-l-w1", autostart: false do |subconfig|
-        subconfig.vm.box = LINUX_IMAGE
+        subconfig.vm.box = $LinuxImage
         subconfig.vm.hostname = "k-l-w1"
-        subconfig.vm.network :public_network, bridge: $VirtualSwitchName
-        subconfig.vm.synced_folder "../vagrant-synced/kube", "/vagrant", type: "smb"
         subconfig.vm.provision "shell", path: "00-ubuntu.sh"
         subconfig.vm.provision "shell", path: "01-kubernetes.sh"
         subconfig.vm.provision "shell", path: "02-worker.sh"
+        subconfig.vm.synced_folder "../vagrant-synced/kube", "/vagrant", type: $SyncedFolderType
         subconfig.vm.provider "hyperv" do |h|
+            subconfig.vm.network :public_network, bridge: $VirtualSwitchName
             h.enable_virtualization_extensions = true
             h.differencing_disk = true
             h.cpus = 4
             h.memory = 1024
             h.maxmemory = 4096
             h.vmname = "k-l-w1"
-        end   
+        end
+        subconfig.vm.provider "virtualbox" do |v|
+            subconfig.vm.network :private_network, type: "dhcp"
+            v.linked_clone = true
+            v.memory = 1024
+            v.cpus = 2
+            v.name = "k-l-w1"
+        end
     end
     # TODO: add routes to Linux pods from Windows; depends on HNS config currently in **start-kubelet.ps1**
     # Error output below if **start-kubelet.ps1** has not be ran successfully
@@ -79,23 +109,30 @@ Vagrant.configure("2") do |config|
     # k-w-w1:     + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,AddRoutes.ps1
     (1..2).each do |i|
         config.vm.define "k-w-w#{i}" do |subconfig|
-            subconfig.vm.box = IMAGE
+            subconfig.vm.box = $WindowsImage
             subconfig.vm.communicator = "winrm"
             subconfig.vm.hostname = "k-w-w#{i}"
-            subconfig.vm.network :public_network, bridge: $VirtualSwitchName
             subconfig.vm.synced_folder ".", "/vagrant", disabled: true
             #subconfig.vm.synced_folder "../vagrant-synced/kube-win", "c:/k/", type: "smb" #experienced issues with permissions, perhaps user error though
             subconfig.vm.provision "file", source: "../vagrant-synced/kube-win", destination: "c:/k"
             subconfig.vm.provision "shell", path: "./00-windows.ps1", :args => ["-ClusterCIDR", ClusterCIDR], privileged: true
             #subconfig.vm.provision "shell", path: "./01-routes.ps1", :args => ["-ClusterCIDR", ClusterCIDRShort, "-counter", "#{i}"], privileged: true
             subconfig.vm.provider "hyperv" do |h|
+                subconfig.vm.network :public_network, bridge: $VirtualSwitchName
                 h.enable_virtualization_extensions = true
                 h.differencing_disk = true
                 h.cpus = 4
                 h.memory = 2048
                 h.maxmemory = 2048 
                 h.vmname = "k-w-w#{i}"
-            end   
+            end
+        subconfig.vm.provider "virtualbox" do |v|
+                subconfig.vm.network :private_network, type: "dhcp"
+                v.linked_clone = true
+                v.memory = 1024
+                v.cpus = 2
+                v.name = "k-w-w#{i}"
+            end
         end
     end
 end


### PR DESCRIPTION
This is a first stab at adding VirtualBox support.

Some changes include:
- Switching to the ubuntu/xenial64 box and making sure Python is installed on the Ubuntu VM (it's not present in that box by default). The generic/ubuntu box doesn't work with Virtualbox because it doesn't have the Virtualbox extensions installed so the file share doesn't work.
- Using `mkdir -p` to prevent failures when a directory already exists
- Running `chmod +x` on some of the shell scripts, which weren't marked as executable by default. 
- Probe the `enp0s8` NIC to get the IP address of the master. SystemD changed NIC naming in Linux so here's to that.
- Update the `Vagrantfile` to support Virtualbox.

The `Vagrantfile` changes are WIP, I haven't found a good way yet to run code conditionally in Vagrant (e.g. use a bridged network with Hyper-V and NAT + a Host-Only network with Virtualbox).

The PR has been split in separate commits so you could cherry-pick any commit if you want.

At the very least, the master is running:

```
vagrant@k-m1:~$ /vagrant/kube/bin/kubectl get pods --all-namespaces
NAMESPACE     NAME                                   READY     STATUS             RESTARTS   AGE
kube-system   heapster-v1.2.0-644485c79d-22lv8       2/2       Running            0          12m
kube-system   kube-addon-manager-k-m1                1/1       Running            0          11m
kube-system   kube-apiserver-k-m1                    1/1       Running            2          11m
kube-system   kube-controller-manager-k-m1           1/1       Running            0          11m
kube-system   kube-dns-v20-pbpdq                     1/3       CrashLoopBackOff   12         12m
kube-system   kube-dns-v20-xhjbt                     2/3       CrashLoopBackOff   12         12m
kube-system   kube-etcd-k-m1                         1/1       Running            0          11m
kube-system   kube-scheduler-k-m1                    1/1       Running            0          11m
kube-system   kubernetes-dashboard-9488dbf5f-zgnfw   1/1       Running            0          12m
```

As a side-note, any reason you're not using the [Kubernetes apt repositories to install `kubectl`](https://kubernetes.io/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl)?